### PR TITLE
perf: 대용량 파일 업로드 시 비동기 처리 도입 (resolves #1)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -160,11 +160,12 @@ async def upload_pdf(
     book_dir = os.path.join(STORAGE_DIR, book.uuid_key)
     os.makedirs(book_dir, exist_ok=True)
     
-    # 4. 원본 PDF 저장 (Streaming 방식 복사로 RAM 보호)
+    # 4. 원본 PDF 저장 (Streaming 방식 복사로 RAM 보호 및 비동기 처리)
     pdf_path = os.path.join(book_dir, "original.pdf")
-    import shutil
-    with open(pdf_path, "wb") as f:
-        shutil.copyfileobj(file.file, f)
+    import aiofiles
+    async with aiofiles.open(pdf_path, 'wb') as f:
+        while chunk := await file.read(1024 * 1024):  # 1MB 씩 청크 읽기
+            await f.write(chunk)
         
     # 5. 백그라운드 변환 가동
     background_tasks.add_task(process_pdf_task, pdf_path, book_dir, book.uuid_key, date_str, split_pages)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ google-cloud-storage
 google-cloud-firestore
 passlib
 bcrypt==3.2.0
+aiofiles>=23.2.1


### PR DESCRIPTION
### 🚀 작업 내용
- 기존 동기적인 `shutil.copyfileobj` 로직을 `aiofiles`를 활용한 비동기 I/O로 교체했습니다.
- 파일 전송 시 발생하는 FastAPI 이벤트 루프 블로킹(Blocking) 현상을 방지하여 서버의 동시 처리 능력을 향상시켰습니다.
- `requirements.txt`에 `aiofiles` 의존성을 추가했습니다.

### 🔗 연관 이슈
- Resolves #1

### ✅ 체크리스트
- [x] 코드가 정상적으로 빌드되는가?
- [x] 새로운 의존성이 추가되었는가?