### PR TITLE
perf: GCS 대량 파일 병렬 삭제 로직 적용 (resolves #2)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -224,12 +224,17 @@ def delete_single_flipbook(uuid_key: str):
     date_str = book_data.get("date_folder", "")
     doc_ref.delete()
     
-    # 3. GCS 블롭 소거 (Prefix 기반)
+    # 3. GCS 블롭 소거 (Prefix 기반) - 멀티스레딩 병렬 삭제 적용
     try:
+        from concurrent.futures import ThreadPoolExecutor
         prefix_path = f"flipbooks/{date_str}/{uuid_key}/" if date_str else f"flipbooks/{uuid_key}/"
-        blobs = bucket.list_blobs(prefix=prefix_path)
-        for b in blobs:
-            b.delete()
+        blobs = list(bucket.list_blobs(prefix=prefix_path)) # 리스트로 변환하여 로드
+        
+        if blobs:
+            # 최대 10개의 워커 스레드로 동시 삭제 API 호출 (I/O 바운드 작업 최적화)
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                list(executor.map(lambda b: b.delete(), blobs))
+                
     except Exception as e:
          print(f"⚠️ [Delete] GCS cleanup failed for book-{uuid_key}: {str(e)}")
 


### PR DESCRIPTION
### 🚀 작업 내용
- 폴더나 문서를 삭제할 때 GCS(Google Cloud Storage)에 저장된 다수의 WebP 이미지를 순차적으로(for loop) 지우던 비효율적인 로직을 수정했습니다.
- `ThreadPoolExecutor`를 도입하여 한 번에 최대 10개의 워커(Worker)가 병렬로 삭제 API를 호출하도록 변경했습니다.
- 이로 인해 프론트엔드에서 삭제 버튼 클릭 시 응답을 기다리는 대기 시간(Latency)이 대폭 감소했습니다.

### 🔗 연관 이슈
- Resolves #2

### ✅ 체크리스트
- [x] 코드가 정상적으로 빌드되는가?
- [x] `concurrent.futures`를 올바르게 임포트하고 활용했는가?